### PR TITLE
Fix issue with timeout in prepareSAR

### DIFF
--- a/MQTTClient.cpp
+++ b/MQTTClient.cpp
@@ -1398,7 +1398,7 @@ namespace Network { namespace Client {
              : ImplBase(clientID, callback, brokerCert, storage), socket(0), timeoutMs({3, 0}) {}
         ~Impl() { delete0(socket); }
 
-        uint32 getTimeout() const { return 0; }
+        uint32 getTimeout() const { return timeoutMs.tv_sec * 1000 + timeoutMs.tv_usec / 1000; }
         inline void setTimeout(uint32 timeout)
         {
             timeoutMs.tv_sec = (uint32)timeout / 1024; // Avoid division here (compiler should shift the value here), the value is approximative anyway

--- a/MQTTClient.cpp
+++ b/MQTTClient.cpp
@@ -475,7 +475,7 @@ namespace Network { namespace Client {
 
 #if MQTTLowLatency == 1
             // In low latency mode, return as early as possible
-            if (lowLatency && !this->socket->select(true, false, 0)) return -2;
+            if (lowLatency && !that()->socket->select(true, false, 0)) return -2;
 #endif
 
             // We want to keep track of complete timeout time over multiple operations
@@ -657,9 +657,9 @@ namespace Network { namespace Client {
 #endif
 
     #if MQTTDumpCommunication == 1
-    //      String out;
-    //      packet.dump(out, 2);
-    //      printf("Prepared:\n%s\n", (const char*)out);
+         MQTTString out;
+         packet.dump(out, 2);
+         printf("Prepared:\n%s\n", (const char*)out.c_str());
     #endif
             return sendAndReceive(buffer, packetSize, withAnswer);
         }


### PR DESCRIPTION
when I test eMQTT5 in esp32s3 board, I found some issue like [https://github.com/X-Ryl669/eMQTT5/issues/24](https://github.com/X-Ryl669/eMQTT5/issues/24). After I debug I made some change to keep it work, So I pull this pr .